### PR TITLE
Add GitHub profile features

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
+# GitHub Profile
 
+<table>
+  <tr>
+    <td style="border: none;">
+      <img src="https://github-readme-stats.vercel.app/api?username=josephabonasara&show_icons=true&theme=radical" alt="josephabonasara-readme-stats" />
+    </td>
+    <td style="border: none;">
+      <img src="https://github-readme-streak-stats.herokuapp.com/?user=josephabonasara&theme=radical" alt="GitHub Streak" />
+    </td>
+  </tr>
+</table>
+
+![My Contributions](https://github-readme-activity-graph.vercel.app/graph?username=josephabonasara&bg_color=0d1117&color=58a6ff&line=1f6feb&point=ffffff&area=true&hide_border=false)
+
+## Top Programming Languages Card
+![Top Programming Languages Card](https://github-readme-stats.vercel.app/api/top-langs/?username=josephabonasara&layout=compact&theme=radical)
+
+## GitHub Profile Trophy
+![trophy](https://github-profile-trophy.vercel.app/?username=josephabonasara&theme=radical)


### PR DESCRIPTION
Add GitHub profile features to `README.md`.

* Add GitHub Readme Stats section with a table format.
* Add GitHub Contributions Streak section within the table.
* Add GitHub Activity Graph below the table.
* Add Top Programming Languages Card section.
* Add GitHub Profile Trophy section.

